### PR TITLE
Add TMDB v4 token support, migrate to axios, and add GitHub Pages deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Preferred: TMDB v4 Read Access Token (server-side only)
+API_READ_ACCESS_TOKEN=your_tmdb_v4_read_access_token
+
+# Optional fallback for local/dev only
+API_KEY=your_tmdb_v3_api_key

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,49 @@
+name: Deploy frontend to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Inject runtime config
+        run: |
+          API_BASE_URL="${{ secrets.API_BASE_URL }}"
+          if [ -z "$API_BASE_URL" ]; then
+            API_BASE_URL="http://localhost:4200"
+          fi
+          cat > public/js/config.js <<CONFIG
+          window.MOVIERAMA_CONFIG = {
+            apiBaseUrl: '$API_BASE_URL'
+          };
+          CONFIG
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,8 +1,41 @@
 # MovieRama
-## Setup guide
-1. Run "npm install".
-2. Create a file with name ".env" inside the root folder of the app and insert the line "API_KEY=[key]" in it, replacing [key] with your key for the-movie-db API.
-3. Run "npm start" to start the local server.
-4. Open the url "localhost:4200" with a browser.
-## Live website
-To checkout the app, go to http://movie-land.herokuapp.com where it is deployed.
+
+MovieRama is a lightweight movie discovery web app powered by The Movie Database (TMDB).
+
+## Tech stack
+
+- Vanilla JavaScript frontend
+- Node.js + Express backend proxy
+
+## Main features
+
+- Search movies and browse paginated results.
+- Infinite scrolling for seamless discovery.
+- Expandable movie cards with:
+  - trailer embeds (YouTube/Vimeo when available)
+  - user reviews with “read more” expansion
+  - similar movie recommendations
+- Genre, release year, overview, and rating metadata on each card.
+- Lazy loading for poster and icon assets.
+- Backend TMDB proxy with server-side credential handling (`API_READ_ACCESS_TOKEN` or `API_KEY`).
+
+## Development
+
+### Prerequisites
+
+- Node.js 18+
+- TMDB credential as environment variable (`API_READ_ACCESS_TOKEN` preferred, `API_KEY` supported)
+
+### Run locally
+
+```bash
+npm install
+npm start
+```
+
+Open `http://localhost:4200`.
+
+## Scripts
+
+- `npm start` — start server
+- `npm test` — syntax checks

--- a/api.js
+++ b/api.js
@@ -1,18 +1,43 @@
-var express = require('express')
-var router = express.Router();
-const request = require('request');
-require('dotenv').config()
+const express = require('express');
+const axios = require('axios');
 
+require('dotenv').config();
+
+const router = express.Router();
 const apiKey = process.env.API_KEY;
+const apiReadAccessToken = process.env.API_READ_ACCESS_TOKEN;
+
+function buildTmdbRequestConfig(clientParams) {
+    const config = { params: clientParams };
+
+    if (apiReadAccessToken) {
+        config.headers = {
+            Authorization: `Bearer ${apiReadAccessToken}`
+        };
+    } else {
+        config.params.api_key = apiKey;
+    }
+
+    return config;
+}
 
 // acts as middleware between front-end and the-movie-db api
-router.get('/', function (req, res) {
-    request('https://api.themoviedb.org/3' + req.query.endPoint + '?api_key=' + apiKey + req.query.params, { json: true }, (err, _, body) => {
-        if (err)
-            return console.log(err);
+router.get('/', async function (req, res) {
+    try {
+        const forwardedParams = req.query.params
+            ? Object.fromEntries(new URLSearchParams(req.query.params))
+            : {};
 
-        res.send(body)
-    });
-})
+        const response = await axios.get(
+            `https://api.themoviedb.org/3${req.query.endPoint}`,
+            buildTmdbRequestConfig(forwardedParams)
+        );
+
+        res.send(response.data);
+    } catch (error) {
+        console.error(error.message);
+        res.status(502).send({ error: 'Unable to fetch data from The Movie Database API.' });
+    }
+});
 
 module.exports = router;

--- a/package.json
+++ b/package.json
@@ -1,25 +1,25 @@
 {
-    "name": "movierama",
-    "version": "1.0.0",
-    "description": "",
-    "main": "app.js",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "start": "node app.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/AntonisKl/MovieRama.git"
-    },
-    "author": "Antonis",
-    "license": "ISC",
-    "bugs": {
-        "url": "https://github.com/AntonisKl/MovieRama/issues"
-    },
-    "homepage": "https://github.com/AntonisKl/MovieRama#readme",
-    "dependencies": {
-        "dotenv": "^8.2.0",
-        "express": "^4.17.3",
-        "request": "^2.88.2"
-    }
+  "name": "movierama",
+  "version": "1.0.0",
+  "description": "A lightweight movie discovery app powered by TMDB, with a static frontend and Node proxy backend.",
+  "main": "app.js",
+  "scripts": {
+    "test": "node --check app.js && node --check api.js",
+    "start": "node app.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AntonisKl/MovieRama.git"
+  },
+  "author": "Antonis",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/AntonisKl/MovieRama/issues"
+  },
+  "homepage": "https://github.com/AntonisKl/MovieRama#readme",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.21.2",
+    "axios": "^1.7.7"
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
     <script type="text/javascript" src="../js/lazy-load.js"></script>
     <script type="text/javascript" src="../js/utils.js"></script>
     <script type="text/javascript" src="../js/movies-ui.js"></script>
+    <script type="text/javascript" src="../js/config.js"></script>
     <script type="text/javascript" src="../js/api.js"></script>
     <script type="text/javascript" src="../js/infinite-scroll.js"></script>
 

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -1,6 +1,10 @@
 // global variables
 let allGenres = null; // variable in which all the movie DB's genres are stored
 
+const apiBaseUrl = (window.MOVIERAMA_CONFIG && window.MOVIERAMA_CONFIG.apiBaseUrl)
+    ? window.MOVIERAMA_CONFIG.apiBaseUrl
+    : 'http://localhost:4200';
+
 // getUrl: creates the GET request's url and sends it to the function httpGet
 function getUrl(endPoint, params, callback) {
     let paramsS = "";
@@ -13,7 +17,7 @@ function getUrl(endPoint, params, callback) {
         paramsS += ("&" + element);
     })
 
-    let url = "http://localhost:4200/api/" + "?endPoint=" + encodeURIComponent(endPoint) + "&params=" + encodeURIComponent(paramsS);
+    let url = apiBaseUrl + "/api/" + "?endPoint=" + encodeURIComponent(endPoint) + "&params=" + encodeURIComponent(paramsS);
 
     httpGet(url, callback);
 }

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,0 +1,3 @@
+window.MOVIERAMA_CONFIG = {
+  apiBaseUrl: 'http://localhost:4200'
+};

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: movierama-api
+    env: node
+    plan: free
+    buildCommand: npm ci
+    startCommand: npm start
+    envVars:
+      - key: API_READ_ACCESS_TOKEN
+        sync: false
+      - key: API_KEY
+        sync: false


### PR DESCRIPTION
### Motivation
- Support server-side TMDB v4 Read Access Token while keeping a local `API_KEY` fallback for development.
- Replace the deprecated `request` usage with `axios` to improve request handling and error reporting.
- Allow the static frontend to be deployed to GitHub Pages with a runtime-configurable API base URL.
- Provide environment/example files and platform config to simplify deployments and documentation.

### Description
- Rewrote `api.js` to use `axios`, added `API_READ_ACCESS_TOKEN` support, introduced `buildTmdbRequestConfig`, parse forwarded params via `URLSearchParams`, and improved error handling.
- Changed frontend to read `window.MOVIERAMA_CONFIG.apiBaseUrl` by adding `public/js/config.js` and including it in `public/index.html`, and updated `public/js/api.js` to use the runtime `apiBaseUrl` when building API requests.
- Added `/.env.example` and `render.yaml` for deployment guidance and secrets, and updated `README.md` with tech stack, dev instructions, and credential notes.
- Added `/.github/workflows/deploy-pages.yml` to build and deploy the `public` folder to GitHub Pages with a step that injects runtime config from `secrets.API_BASE_URL`, and updated `package.json` to use newer deps (`axios`, updated `dotenv`/`express`) and a `test` script that performs syntax checks.

### Testing
- Ran `npm test` which performs `node --check app.js && node --check api.js`, and the syntax checks passed.
- No automated CI workflow runs were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1df8038248328a396f2ea873bf2b3)