### PR TITLE
Use local SVG data URIs for flags; fix poster handling, HTTPS and lazy-loading for similar cards

### DIFF
--- a/public/js/localization.js
+++ b/public/js/localization.js
@@ -31,8 +31,9 @@ let language, // default: english
         }
     },
     languageImgElem,
-    engImgUrl = "https://lipis.github.io/flag-icon-css/flags/4x3/gb.svg",
-    grImgUrl = "https://lipis.github.io/flag-icon-css/flags/4x3/gr.svg";
+    // Keep flag icons local (data URI) so they always load without third-party dependencies.
+    engImgUrl = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 45'%3E%3CclipPath id='s'%3E%3Cpath d='M0,0 v45 h60 v-45 z'/%3E%3C/clipPath%3E%3Cpath d='M0,0 v45 h60 v-45 z' fill='%23012169'/%3E%3Cpath d='M0,0 L60,45 M60,0 L0,45' stroke='%23fff' stroke-width='9'/%3E%3Cpath d='M0,0 L60,45 M60,0 L0,45' clip-path='url(%23s)' stroke='%23c8102e' stroke-width='6'/%3E%3Cpath d='M30,0 v45 M0,22.5 h60' stroke='%23fff' stroke-width='15'/%3E%3Cpath d='M30,0 v45 M0,22.5 h60' stroke='%23c8102e' stroke-width='9'/%3E%3C/svg%3E",
+    grImgUrl = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 27 18'%3E%3Crect width='27' height='18' fill='%230d5eaf'/%3E%3Cg fill='%23fff'%3E%3Crect y='2' width='27' height='2'/%3E%3Crect y='6' width='27' height='2'/%3E%3Crect y='10' width='27' height='2'/%3E%3Crect y='14' width='27' height='2'/%3E%3C/g%3E%3Crect width='10' height='10' fill='%230d5eaf'/%3E%3Crect x='4' width='2' height='10' fill='%23fff'/%3E%3Crect y='4' width='10' height='2' fill='%23fff'/%3E%3C/svg%3E";
 
 $(document).ready(function() {
     languageImgElem = $("#languageImg");

--- a/public/js/movies-ui.js
+++ b/public/js/movies-ui.js
@@ -17,11 +17,15 @@ function buildReview(review) {
 
 // buildSimilarCard: returns a similar movie's card inside a responsive column
 function buildSimilarCard(similarMovie) {
+    let posterPath = similarMovie["poster_path"];
+    let posterImgElem = posterPath
+        ? `<img src="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 2 3%22 /%3E" data-src="https://image.tmdb.org/t/p/w185_and_h278_bestv2` + posterPath + `" class="card-img-top similar-card-img-top w-auto" alt="Movie poster">`
+        : `<div class="d-flex align-items-center justify-content-center px-2" style="height:278px;color:#6c757d;">No poster</div>`;
+
     return `<div class='col-xs-9 col-sm-9 col-md-9 col-lg-9 d-flex align-items-stretch' style="max-width: 14rem;">
             <div onclick="searchForMovie('` + similarMovie["title"].replace("'", "\\'") + `')" class="card card-hoverable bg-light my-3">
             <div class="text-center bg-light">
-
-            <img src="http://image.tmdb.org/t/p/w185_and_h278_bestv2` + similarMovie["poster_path"] + `" class="card-img-top similar-card-img-top w-auto" alt="Movie poster">
+            ` + posterImgElem + `
             </div>
 
             <div class="card-body align-items-center d-flex justify-content-center" style="padding:0.5em">
@@ -133,6 +137,8 @@ function fillMovieDetails(thisElem, movieId) {
             similarCardsElem.append(buildSimilarCard(similarMovie)); // add similar movie's card to similar movies list element
         });
 
+        startObserving(); // observe newly-added similar movie images for lazy loading
+
         movieCollapse.collapse("show"); // show current collapsible to the user
     });
 }
@@ -163,7 +169,7 @@ function showCards(movies) {
         cardsS += `
                 <div class='col-lg-2 d-flex align-items-strech mx-2 my-4'>
                     <div onclick= "fillMovieDetails(this, ` + movie["id"] + `);" data-expanded="false" class="card card-hoverable hoverable">
-                        ` + (!movie["poster_path"] ? `` : `<img class="card-img-top" src="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 2 3%22 /%3E" data-src="http://image.tmdb.org/t/p/w300_and_h450_bestv2` + movie["poster_path"] + `" alt="Movie poster">`) +
+                        ` + (!movie["poster_path"] ? `` : `<img class="card-img-top" src="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 2 3%22 /%3E" data-src="https://image.tmdb.org/t/p/w300_and_h450_bestv2` + movie["poster_path"] + `" alt="Movie poster">`) +
             `<div class="card-body d-flex flex-column">
                             <h5 class="card-title main-card-title">` + movie["title"] + `</h5>
                             ` + (!movie["overview"] ? `` : ` <p class="movie-overview">` + movie["overview"] + `</p>`) +


### PR DESCRIPTION
### Motivation
- Eliminate third-party dependencies for flag icons so the UI loads reliably without external requests.
- Improve robustness of poster handling for movies and similar-movies when posters are missing or served insecurely.
- Ensure newly injected similar-movie images are observed for lazy-loading.

### Description
- Replaced external flag image URLs in `public/js/localization.js` with inline SVG data URIs for English and Greek flags and added a comment explaining the change.
- Updated `public/js/movies-ui.js` to use HTTPS image URLs for TMDB posters and added a tiny inline SVG placeholder `src` with the real URL in `data-src` for lazy-loading.
- Added conditional rendering for similar movie posters so missing posters show a `No poster` placeholder instead of a broken image.
- Call `startObserving()` after appending similar movie cards so newly-added images are picked up by the lazy-loading observer.

### Testing
- Ran the project's linter via `npm run lint` and the JS test suite via `npm test`, and both succeeded.
- Verified build/packaging step completed successfully in the CI script (no errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2495db59c83289f02c3a3fa7d8665)